### PR TITLE
Fix icons broken in font awesom 5

### DIFF
--- a/layouts/partials/social_links.html
+++ b/layouts/partials/social_links.html
@@ -1,7 +1,8 @@
 <p class="links">
-  <a href="http://www.twitter.com/{{ .Site.Data.Social.twitter }}" target="_new"><i class="fa fa-twitter"></i></a>
-  <a href="{{ .Site.Data.Social.linkedin }}" target="_new"><i class="fa fa-linkedin"></i></a>
-  <a href="https://github.com/{{ .Site.Data.Social.github }}" target="_new"><i class="fa fa-github-alt"></i></a>
-  <a href="https://stackoverflow.com/users/{{ .Site.Data.Social.stackoverflow }}" target="_new"><i class="fa fa-stack-overflow"></i></a>
+  <a href="http://www.twitter.com/{{ .Site.Data.Social.twitter }}" target="_new"><i class="fab fa-twitter"></i></a>
+  <a href="{{ .Site.Data.Social.linkedin }}" target="_new"><i class="fab fa-linkedin"></i></a>
+  <a href="https://github.com/{{ .Site.Data.Social.github }}" target="_new"><i class="fab fa-github-alt"></i></a>
+  <a href="https://stackoverflow.com/users/{{ .Site.Data.Social.stackoverflow }}" target="_new"><i
+      class="fab fa-stack-overflow"></i></a>
   <a href="{{ .Site.BaseURL }}/feed.xml" target="_new"><i class="fa fa-rss"></i></a>
 </p>


### PR DESCRIPTION
Some of the icons got broken because the font awesome 5 class changed
from `fa` to `fab`. Note not all of them did.