### PR TITLE
Change links to be canonical with archive icon if not original content

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -14,7 +14,17 @@
                     {{ range $year.Pages }}
                     {{ if eq .Type "posts"}}
                     <li>
+                        {{ if isset .Params "canonical" }}
+                        <a href="{{ .Params.canonical }}" target="_blank" rel="noopener noreferrer">
+                            {{ .Title }}
+                            <i class="fas fa-external-link-alt" style="font-size: 0.5em;" title="Canonical version"></i>
+                        </a>
+                        <a href="{{ .Permalink }}">
+                            <i class="fas fa-archive" style="font-size: 0.5em;" title="Archived version"></i>
+                        </a>
+                        {{ else }}
                         <a href="{{ .Permalink }}">{{ .Title }}</a>
+                        {{ end }}
                         <small class="hidden-xs">{{ .Date.Format "January 2"}}</small>
                     </li>
                     {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -27,7 +27,17 @@
 
                     {{ range first 5 (where site.RegularPages "Type" "eq" "posts") }}
                     <li>
+                        {{ if isset .Params "canonical" }}
+                        <a href="{{ .Params.canonical }}" target="_blank" rel="noopener noreferrer">
+                            {{ .Title }}
+                            <i class="fas fa-external-link-alt" style="font-size: 0.5em;" title="Canonical version"></i>
+                        </a>
+                        <a href="{{ .Permalink }}">
+                            <i class="fas fa-archive" style="font-size: 0.5em;" title="Archived version"></i>
+                        </a>
+                        {{ else }}
                         <a href="{{ .Permalink }}">{{ .Title }}</a>
+                        {{ end }}
                         <small class="hidden-xs">{{ .Date.Format "January 2, 2006"}}</small>
                     </li>
                     {{ end }}


### PR DESCRIPTION
Sometimes you may want to link to or archive a blog post that you wrote on another site. 

You can set the `canonical` parameter of a blog post to point to the original.

```markdown
---
title: "My awesome guest blog post on blog X"
date: 2020-07-23T00:00:00+00:00
draft: false
author: "Jacob Tomlinson"
categories:
  - blog
tags:
  - Guest post
canonical: LINK TO ORIGINAL POST
---

DESCRIPTION OF POST OR ARCHIVE OF WHOLE POST
```

This will correctly set canonical headers so that search engines only rank the original and now with this PR it also updates the link in the lists of posts to go to the canonical URL and shows an "external link" icon and has an "archive" icon linking to your cached copy on your blog.

![Top post is a link to the Dask blog](https://user-images.githubusercontent.com/1610850/90643421-81f4da00-e22b-11ea-9081-ea354ce20aac.png)
